### PR TITLE
Add a COMMIT_BODY option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Here are all the inputs [repo-file-sync-action](https://github.com/BetaHuhn/repo
 | `PR_LABELS` | Labels which will be added to the pull request. Set to false to turn off | **No** | sync |
 | `ASSIGNEES` | People to assign to the pull request | **No** | N/A |
 | `COMMIT_PREFIX` | Prefix for commit message and pull request title | **No** | 🔄 |
+| `COMMIT_BODY` | Commit message body. Will be appended to commit message, separated by two line returns. | **No** | '' |
 | `COMMIT_EACH_FILE` | Commit each file seperately | **No** | true |
 | `GIT_EMAIL` | The e-mail address used to commit the synced files | **No** | the email of the PAT used |
 | `GIT_USERNAME` | The username used to commit the synced files | **No** | the username of the PAT used |

--- a/README.md
+++ b/README.md
@@ -320,6 +320,27 @@ The new branch will then be `custom-branch/SOURCE_BRANCH_NAME`.
 
 > You can use `SOURCE_REPO_NAME` in your custom branch prefix as well and it will be replaced with the actual repo name
 
+### Custom commit body
+
+You can specify a custom commit body. This will be appended to the commit message, separated by two new lines. For example:
+
+**.github/workflows/sync.yml**
+
+```yml
+- name: Run GitHub File Sync
+  uses: BetaHuhn/repo-file-sync-action@v1
+  with:
+    GH_PAT: ${{ secrets.GH_PAT }}
+    COMMIT_BODY: "Change-type: patch"
+```
+
+The above example would result in a commit message that looks something like this:
+```
+🔄 Synced local '<filename>' with remote '<filename>'
+
+Change-type: patch
+```
+
 ### Advanced sync config
 
 Here's how I keep common files in sync across my repositories. The main repository [`github-files`](https://github.com/BetaHuhn/github-files) contains all the files I want to sync and the [repo-file-sync-action](https://github.com/BetaHuhn/repo-file-sync-action) Action which runs on every push.

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: |
       Prefix for commit message and pull request title. Defaults to 🔄
     required: false
+  COMMIT_BODY:
+    description: |
+      Commit message body. Will be appended to commit message, separated by two line returns. Defaults to ''
+    required: false
   COMMIT_EACH_FILE:
     description: |
       Commit each file seperately. Defaults to true

--- a/dist/index.js
+++ b/dist/index.js
@@ -32842,6 +32842,10 @@ try {
 			key: 'CONFIG_PATH',
 			default: '.github/sync.yml'
 		}),
+		COMMIT_BODY: getInput({
+			key: 'COMMIT_BODY',
+			default: ''
+		}),
 		COMMIT_PREFIX: getInput({
 			key: 'COMMIT_PREFIX',
 			default: '🔄'
@@ -33035,6 +33039,7 @@ const {
 	GIT_USERNAME,
 	GIT_EMAIL,
 	TMP_DIR,
+	COMMIT_BODY,
 	COMMIT_PREFIX,
 	GITHUB_REPOSITORY,
 	OVERWRITE_EXISTING_PR,
@@ -33122,8 +33127,10 @@ const init = (repo) => {
 	}
 
 	const commit = async (msg) => {
-		const message = msg !== undefined ? msg : `${ COMMIT_PREFIX } Synced file(s) with ${ GITHUB_REPOSITORY }`
-
+		let message = msg !== undefined ? msg : `${ COMMIT_PREFIX } Synced file(s) with ${ GITHUB_REPOSITORY }`
+		if (COMMIT_BODY) {
+			message += `\n\n${ COMMIT_BODY }`
+		}
 		return execCmd(
 			`git commit -m "${ message }"`,
 			workingDir

--- a/src/config.js
+++ b/src/config.js
@@ -23,6 +23,10 @@ try {
 			key: 'CONFIG_PATH',
 			default: '.github/sync.yml'
 		}),
+		COMMIT_BODY: getInput({
+			key: 'COMMIT_BODY',
+			default: ''
+		}),
 		COMMIT_PREFIX: getInput({
 			key: 'COMMIT_PREFIX',
 			default: '🔄'

--- a/src/git.js
+++ b/src/git.js
@@ -7,6 +7,7 @@ const {
 	GIT_USERNAME,
 	GIT_EMAIL,
 	TMP_DIR,
+	COMMIT_BODY,
 	COMMIT_PREFIX,
 	GITHUB_REPOSITORY,
 	OVERWRITE_EXISTING_PR,
@@ -94,8 +95,10 @@ const init = (repo) => {
 	}
 
 	const commit = async (msg) => {
-		const message = msg !== undefined ? msg : `${ COMMIT_PREFIX } Synced file(s) with ${ GITHUB_REPOSITORY }`
-
+		let message = msg !== undefined ? msg : `${ COMMIT_PREFIX } Synced file(s) with ${ GITHUB_REPOSITORY }`
+		if (COMMIT_BODY) {
+			message += `\n\n${ COMMIT_BODY }`
+		}
 		return execCmd(
 			`git commit -m "${ message }"`,
 			workingDir


### PR DESCRIPTION
Some GitHub actions can check for specific content in a commit message's body. For example a versionbot that checks for content like `Change-type: patch`.

This change allows the calling workflow to specify a string to use as the commit body. This string will be appended to the commit message, separated by two new lines.

Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>