### PR TITLE
feat: Add PR_BODY option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: |
       Labels which will be added to the pull request. Defaults to sync. Set to false to turn off
     required: false
+  PR_BODY:
+    description: |
+      Additional content to add in the PR description. Defaults to ''
+    required: false
   ASSIGNEES:
     description: |
       People to assign to the pull request. Defaults to none

--- a/src/config.js
+++ b/src/config.js
@@ -46,7 +46,7 @@ try {
 		}),
 		PR_BODY: getInput({
 			key: 'PR_BODY',
-			default: [ '' ]
+			default: ''
 		}),
 		ASSIGNEES: getInput({
 			key: 'ASSIGNEES',

--- a/src/config.js
+++ b/src/config.js
@@ -44,6 +44,10 @@ try {
 			type: 'array',
 			disableable: true
 		}),
+		PR_BODY: getInput({
+			key: 'PR_BODY',
+			default: [ '' ]
+		}),
 		ASSIGNEES: getInput({
 			key: 'ASSIGNEES',
 			type: 'array'

--- a/src/git.js
+++ b/src/git.js
@@ -13,6 +13,7 @@ const {
 	COMMIT_PREFIX,
 	GITHUB_REPOSITORY,
 	OVERWRITE_EXISTING_PR,
+	PR_BODY,
 	BRANCH_PREFIX
 } = require('./config')
 
@@ -195,6 +196,8 @@ class Git {
 			Synced local file(s) with [${ GITHUB_REPOSITORY }](https://github.com/${ GITHUB_REPOSITORY }).
 
 			${ changedFiles }
+
+			${ PR_BODY }
 
 			---
 

--- a/src/git.js
+++ b/src/git.js
@@ -195,9 +195,9 @@ class Git {
 		const body = dedent(`
 			Synced local file(s) with [${ GITHUB_REPOSITORY }](https://github.com/${ GITHUB_REPOSITORY }).
 
-			${ changedFiles }
-
 			${ PR_BODY }
+			
+			${ changedFiles }
 
 			---
 


### PR DESCRIPTION
This PR adds a PR body input to the action, that can be used to add additional text to the PR description. This is useful when trying the explain more about the PR such as the cause behind its creation and how the future changes will lead to a forced push instead of a new PR.

Originally discussed in #78.