### PR TITLE
Display notice with PR link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ const run = async () => {
 
 				const pullRequest = await git.createOrUpdatePr(COMMIT_EACH_FILE ? changedFiles : '')
 
-				core.info(`Pull Request #${ pullRequest.number } created/updated: ${ pullRequest.html_url }`)
+				core.notice(`Pull Request #${ pullRequest.number } created/updated: ${ pullRequest.html_url }`)
 
 				core.setOutput('pull_request_number', pullRequest.number)
 				core.setOutput('pull_request_url', pullRequest.html_url)


### PR DESCRIPTION
This way the PR links are visible without opening the log of the action run.
Note: There is a limit of 10 notices per run
Demo: [here](https://github.com/Nef10/sync-test/actions/runs/1204289659)

When working on this I noticed that the current version does not seem to be built correctly. When I check out develop and run a build there is a diff to the checked in dist file. This change seems to be the bump of `@actions/core` to 1.5.0. This version is required for this change, so please make sure to update the dependencies to the version of the lock file before building.

Fixes #100 