### PR TITLE
✨ Add COMMIT_AS_PR_TITLE option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
 #### Token
 In order for the Action to access your repositories you have to specify a [Personal Access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token) as the value for `GH_PAT` (`GITHUB_TOKEN` will **not** work). The PAT needs the full repo scope ([#31](https://github.com/BetaHuhn/repo-file-sync-action/discussions/31#discussioncomment-674804)).
 
-It is recommneded to set the token as a
+It is recommended to set the token as a
 [Repository Secret](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository).
 
 Alternatively, you can provide the token of a GitHub App Installation via the `GH_INSTALLATION_TOKEN` input. You can obtain such token for example via [this](https://github.com/marketplace/actions/github-app-token) action. Tokens from apps have the advantage that they provide more granular access control.
@@ -108,7 +108,8 @@ Here are all the inputs [repo-file-sync-action](https://github.com/BetaHuhn/repo
 | `ASSIGNEES` | People to assign to the pull request | **No** | N/A |
 | `COMMIT_PREFIX` | Prefix for commit message and pull request title | **No** | 🔄 |
 | `COMMIT_BODY` | Commit message body. Will be appended to commit message, separated by two line returns. | **No** | '' |
-| `ORIGINAL_MESSAGE` | Use original commit message instead. Only works if the file(s) where changed and the action was triggered by pushing a single commit. | **No** | false |
+| `ORIGINAL_MESSAGE` | Use original commit message instead. Only works if the file(s) were changed and the action was triggered by pushing a single commit. | **No** | false |
+| `COMMIT_AS_PR_TITLE` | Use first line of the commit message as PR title. Only works if `ORIGINAL_MESSAGE` is `true` and working. | **No** | false |
 | `COMMIT_EACH_FILE` | Commit each file seperately | **No** | true |
 | `GIT_EMAIL` | The e-mail address used to commit the synced files | **Only when using installation token** | the email of the PAT used |
 | `GIT_USERNAME` | The username used to commit the synced files | **Only when using installation token** | the username of the PAT used |

--- a/action.yml
+++ b/action.yml
@@ -67,6 +67,10 @@ inputs:
     description: |
       Re-use the original commit message for commits. Works only if the action is triggered by pushing one commit. Defaults to false
     required: false
+  COMMIT_AS_PR_TITLE:
+    description: |
+      Re-use the commit message as PR title. Works only if ORIGINAL_MESSAGE is on and PR has one commit. Defaults to false
+    required: false
   SKIP_PR:
     description: |
       Skips creating a Pull Request and pushes directly to the default branch. Defaults to false

--- a/src/config.js
+++ b/src/config.js
@@ -100,6 +100,11 @@ try {
 			type: 'boolean',
 			default: false
 		}),
+		COMMIT_AS_PR_TITLE: getInput({
+			key: 'COMMIT_AS_PR_TITLE',
+			type: 'boolean',
+			default: false
+		}),
 		BRANCH_PREFIX: getInput({
 			key: 'BRANCH_PREFIX',
 			default: 'repo-sync/SOURCE_REPO_NAME'

--- a/src/git.js
+++ b/src/git.js
@@ -249,7 +249,7 @@ class Git {
 		})
 	}
 
-	async createOrUpdatePr(changedFiles) {
+	async createOrUpdatePr(changedFiles, title) {
 		const body = dedent(`
 			Synced local file(s) with [${ GITHUB_REPOSITORY }](https://github.com/${ GITHUB_REPOSITORY }).
 
@@ -268,6 +268,7 @@ class Git {
 			const { data } = await this.github.pulls.update({
 				owner: this.repo.user,
 				repo: this.repo.name,
+				title: `${ COMMIT_PREFIX } Synced file(s) with ${ GITHUB_REPOSITORY }`,
 				pull_number: this.existingPr.number,
 				body: body
 			})
@@ -280,7 +281,7 @@ class Git {
 		const { data } = await this.github.pulls.create({
 			owner: this.repo.user,
 			repo: this.repo.name,
-			title: `${ COMMIT_PREFIX } Synced file(s) with ${ GITHUB_REPOSITORY }`,
+			title: title === undefined ? `${ COMMIT_PREFIX } Synced file(s) with ${ GITHUB_REPOSITORY }` : title,
 			body: body,
 			head: this.prBranch,
 			base: this.baseBranch


### PR DESCRIPTION
This option allows to use the first line of commit message as PR
title. It requires that ORIGINAL_MESSAGE is on and working (meaning the
file(s) were changed and the action was triggered by pushing a single
commit)

Fixes #103

Demo:
1) First commit sets the PR title correctly, but when a second commit is added to the PR it reverts the title: https://github.com/Nef10/test-sync/pull/81
2) Title not set because useOriginalCommitMessage is not true (as the change is not triggered by a commit): https://github.com/Nef10/test-sync/pull/82
3) With COMMIT_AS_PR_TITLE off: https://github.com/Nef10/test-sync/pull/83