### PR TITLE
🐛 Include hidden files in check for orphaned files

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17829,8 +17829,8 @@ const copy = async (src, dest, deleteOrphaned, exclude) => {
 	// If it is a directory and deleteOrphaned is enabled - check if there are any files that were removed from source dir and remove them in destination dir
 	if (deleteOrphaned) {
 
-		const srcFileList = await readfiles(src, { readContents: false })
-		const destFileList = await readfiles(dest, { readContents: false })
+		const srcFileList = await readfiles(src, { readContents: false, hidden: true })
+		const destFileList = await readfiles(dest, { readContents: false, hidden: true })
 
 		for (const file of destFileList) {
 			if (srcFileList.indexOf(file) === -1) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -80,8 +80,8 @@ const copy = async (src, dest, deleteOrphaned, exclude) => {
 	// If it is a directory and deleteOrphaned is enabled - check if there are any files that were removed from source dir and remove them in destination dir
 	if (deleteOrphaned) {
 
-		const srcFileList = await readfiles(src, { readContents: false })
-		const destFileList = await readfiles(dest, { readContents: false })
+		const srcFileList = await readfiles(src, { readContents: false, hidden: true })
+		const destFileList = await readfiles(dest, { readContents: false, hidden: true })
 
 		for (const file of destFileList) {
 			if (srcFileList.indexOf(file) === -1) {


### PR DESCRIPTION
Fixes #156.

Enables the `hidden` files option of the [node-readfiles](https://github.com/guatedude2/node-readfiles#options) library used to check for orphaned files.