### PR TITLE
🐛 Fix commit message escaping

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -17640,7 +17640,7 @@ class Git {
 			message += `\n\n${ COMMIT_BODY }`
 		}
 		return execCmd(
-			`git commit -m "${ message.replace(/"/g, '\\"') }"`,
+			`git commit -m '${ message.replace(/'/g, '\'\\\'\'') }'`,
 			this.workingDir
 		)
 	}

--- a/src/git.js
+++ b/src/git.js
@@ -227,7 +227,7 @@ class Git {
 			message += `\n\n${ COMMIT_BODY }`
 		}
 		return execCmd(
-			`git commit -m "${ message.replace(/"/g, '\\"') }"`,
+			`git commit -m '${ message.replace(/'/g, '\'\\\'\'') }'`,
 			this.workingDir
 		)
 	}


### PR DESCRIPTION
fixes #125 

Hi @BetaHuhn, 

The source of the issue is related to the [bash command substitution](https://www.gnu.org/software/bash/manual/bash.html#Command-Substitution). 

Replaced the execution of the git commit from using double quotes to single quotes. Also, replaced the escaped sequence to escape the single quotes instead of doubles. The escape is a bit funny but all the elements are required. In the git commit message (when inside of single quotes), the `'` must be escaped with `'\''`. 

After the change, the command substitution is not executed, and also the single quotes and double quotes inside the commit message are processed just fine.