### PR TITLE
fix: sanitize `<owner>/.github` style branch names

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -123,7 +123,7 @@ class Git {
 	async createPrBranch() {
 		const prefix = BRANCH_PREFIX.replace('SOURCE_REPO_NAME', GITHUB_REPOSITORY.split('/')[1])
 
-		let newBranch = path.join(prefix, this.repo.branch).replace(/\\/g, '/')
+		let newBranch = path.join(prefix, this.repo.branch).replace(/\\/g, '/').replace(/\/\./g, '/')
 
 		if (OVERWRITE_EXISTING_PR === false) {
 			newBranch += `-${ Math.round((new Date()).getTime() / 1000) }`


### PR DESCRIPTION
Hello 👋  

Thank you for this lovely action 🚀 

When `GITHUB_REPOSITORY` is in the style of `.github` an invalid branch name is created (`.` can't come directly after `/`).

This PR fixes that issue