### PR TITLE
Fix SKIP_PR option for runs with installation token

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -21513,6 +21513,7 @@ const {
 	COMMIT_PREFIX,
 	GITHUB_REPOSITORY,
 	OVERWRITE_EXISTING_PR,
+	SKIP_PR,
 	PR_BODY,
 	BRANCH_PREFIX,
 	FORK
@@ -21785,7 +21786,7 @@ class Git {
 	// Gets the commit list in chronological order
 	async getCommitsToPush() {
 		const output = await execCmd(
-			`git log --format=%H --reverse ${ this.baseBranch }..HEAD`,
+			`git log --format=%H --reverse ${ SKIP_PR === false ? `` : `origin/` }${ this.baseBranch }..HEAD`,
 			this.workingDir
 		)
 
@@ -21820,30 +21821,32 @@ class Git {
 	async createGithubVerifiedCommits() {
 		const commitsData = await this.getCommitsDataToPush()
 
-		// Creates the PR branch if doesn't exists
-		try {
-			await this.github.git.createRef({
-				owner: this.repo.user,
-				repo: this.repo.name,
-				sha: this.lastCommitSha,
-				ref: 'refs/heads/' + this.prBranch
-			})
+		if (SKIP_PR === false) {
+			// Creates the PR branch if doesn't exists
+			try {
+				await this.github.git.createRef({
+					owner: this.repo.user,
+					repo: this.repo.name,
+					sha: this.lastCommitSha,
+					ref: 'refs/heads/' + this.prBranch
+				})
 
-			core.debug(`Created new branch ${ this.prBranch }`)
-		} catch (error) {
-			// If the branch exists ignores the error
-			if (error.message !== 'Reference already exists') throw error
+				core.debug(`Created new branch ${ this.prBranch }`)
+			} catch (error) {
+				// If the branch exists ignores the error
+				if (error.message !== 'Reference already exists') throw error
+			}
 		}
 
 		for (const commitData of commitsData) {
 			await this.createGithubTreeAndCommit(commitData.tree, commitData.commitMessage)
 		}
 
-		core.debug(`Updating branch ${ this.prBranch } ref`)
+		core.debug(`Updating branch ${ SKIP_PR === false ? this.prBranch : this.baseBranch } ref`)
 		await this.github.git.updateRef({
 			owner: this.repo.user,
 			repo: this.repo.name,
-			ref: `heads/${ this.prBranch }`,
+			ref: `heads/${ SKIP_PR === false ? this.prBranch : this.baseBranch }`,
 			sha: this.lastCommitSha,
 			force: true
 		})

--- a/src/git.js
+++ b/src/git.js
@@ -16,6 +16,7 @@ const {
 	COMMIT_PREFIX,
 	GITHUB_REPOSITORY,
 	OVERWRITE_EXISTING_PR,
+	SKIP_PR,
 	PR_BODY,
 	BRANCH_PREFIX,
 	FORK
@@ -288,7 +289,7 @@ class Git {
 	// Gets the commit list in chronological order
 	async getCommitsToPush() {
 		const output = await execCmd(
-			`git log --format=%H --reverse ${ this.baseBranch }..HEAD`,
+			`git log --format=%H --reverse ${ SKIP_PR === false ? `` : `origin/` }${ this.baseBranch }..HEAD`,
 			this.workingDir
 		)
 
@@ -323,30 +324,32 @@ class Git {
 	async createGithubVerifiedCommits() {
 		const commitsData = await this.getCommitsDataToPush()
 
-		// Creates the PR branch if doesn't exists
-		try {
-			await this.github.git.createRef({
-				owner: this.repo.user,
-				repo: this.repo.name,
-				sha: this.lastCommitSha,
-				ref: 'refs/heads/' + this.prBranch
-			})
+		if (SKIP_PR === false) {
+			// Creates the PR branch if doesn't exists
+			try {
+				await this.github.git.createRef({
+					owner: this.repo.user,
+					repo: this.repo.name,
+					sha: this.lastCommitSha,
+					ref: 'refs/heads/' + this.prBranch
+				})
 
-			core.debug(`Created new branch ${ this.prBranch }`)
-		} catch (error) {
-			// If the branch exists ignores the error
-			if (error.message !== 'Reference already exists') throw error
+				core.debug(`Created new branch ${ this.prBranch }`)
+			} catch (error) {
+				// If the branch exists ignores the error
+				if (error.message !== 'Reference already exists') throw error
+			}
 		}
 
 		for (const commitData of commitsData) {
 			await this.createGithubTreeAndCommit(commitData.tree, commitData.commitMessage)
 		}
 
-		core.debug(`Updating branch ${ this.prBranch } ref`)
+		core.debug(`Updating branch ${ SKIP_PR === false ? this.prBranch : this.baseBranch } ref`)
 		await this.github.git.updateRef({
 			owner: this.repo.user,
 			repo: this.repo.name,
-			ref: `heads/${ this.prBranch }`,
+			ref: `heads/${ SKIP_PR === false ? this.prBranch : this.baseBranch }`,
 			sha: this.lastCommitSha,
 			force: true
 		})


### PR DESCRIPTION
The original implementation for signed commits in #153 did not
consider the `SKIP_PR` flag - if used together with an installation
token it fails now.

This change adds support by:
1) comparing changes against the remote branch, as base branch and HEAD
   are the same
2) Skipping pr branch creation
3) using the base instead of the undefined prBranch as upload target

Fixes #207