### PR TITLE
Don't crash while trying to parse a diff for binary files, fix #128

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -21657,6 +21657,8 @@ class Git {
 		return `\n${ string }`.split('\ndiff --git').slice(1).reduce((resultDict, fileDiff) => {
 			const lines = fileDiff.split('\n')
 			const lastHeaderLineIndex = lines.findIndex((line) => line.startsWith('+++'))
+			if (lastHeaderLineIndex === -1) return resultDict // ignore binary files
+
 			const plainDiff = lines.slice(lastHeaderLineIndex + 1).join('\n').trim()
 			let filePath = ''
 			if (lines[lastHeaderLineIndex].startsWith('+++ b/')) { // every file except removed files

--- a/src/git.js
+++ b/src/git.js
@@ -160,6 +160,8 @@ class Git {
 		return `\n${ string }`.split('\ndiff --git').slice(1).reduce((resultDict, fileDiff) => {
 			const lines = fileDiff.split('\n')
 			const lastHeaderLineIndex = lines.findIndex((line) => line.startsWith('+++'))
+			if (lastHeaderLineIndex === -1) return resultDict // ignore binary files
+
 			const plainDiff = lines.slice(lastHeaderLineIndex + 1).join('\n').trim()
 			let filePath = ''
 			if (lines[lastHeaderLineIndex].startsWith('+++ b/')) { // every file except removed files


### PR DESCRIPTION
<img width="654" alt="image" src="https://user-images.githubusercontent.com/577441/186014878-dd83e306-d6ef-404d-9cad-43c3f5367425.png">

> Error: Cannot read property 'startsWith' of undefined

Config:

```yml
bar/foo@master:
  - test.txt
```

To reproduce, change a binary file (e.g., `*.gz`) in a commit with `test.txt` and try to sync it

Fixes https://github.com/BetaHuhn/repo-file-sync-action/issues/128
