### PR TITLE
Update node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ outputs:
     description: 'The URLs to the created Pull Requests as an array'
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
# Update Node version to 16
Warning when running the action.

<img width="1162" alt="Screenshot 2022-10-24 at 01 08 02" src="https://user-images.githubusercontent.com/45559536/197422711-50715163-53bc-4d43-882c-da4232f1596e.png">
More info:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
