### PR TITLE
Deprecated set-output command needs to be updated as setoutput

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -267,7 +267,7 @@ exports.getBooleanInput = getBooleanInput;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setOutput(name, value) {
     process.stdout.write(os.EOL);
-    command_1.issueCommand('set-output', { name }, value);
+    command_1.issueCommand('setoutput', { name }, value);
 }
 exports.setOutput = setOutput;
 /**


### PR DESCRIPTION
The **set-output** command is being deprecated, now it should be updated and used as **setoutput**.

Below [blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) regarding this update.