### PR TITLE
added support for fine grained tokens

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: | 
       The path for the sync configuration file
     required: false
+  IS_FINE_GRAINED: 
+    description: |
+      Label GH_PAT as a fine grained token
+    required: false
   PR_LABELS:
     description: |
       Labels which will be added to the pull request. Defaults to sync. Set to false to turn off

--- a/dist/index.js
+++ b/dist/index.js
@@ -21277,6 +21277,10 @@ try {
 			key: 'CONFIG_PATH',
 			default: '.github/sync.yml'
 		}),
+		IS_FINE_GRAINED: getInput({
+			key: 'IS_FINE_GRAINED',
+			default: false
+		}),
 		COMMIT_BODY: getInput({
 			key: 'COMMIT_BODY',
 			default: ''
@@ -21506,6 +21510,7 @@ const fs = __nccwpck_require__(7147)
 const {
 	GITHUB_TOKEN,
 	IS_INSTALLATION_TOKEN,
+	IS_FINE_GRAINED,
 	GIT_USERNAME,
 	GIT_EMAIL,
 	TMP_DIR,
@@ -21553,7 +21558,7 @@ class Git {
 		// Set values to current repo
 		this.repo = repo
 		this.workingDir = path.join(TMP_DIR, repo.uniqueName)
-		this.gitUrl = `https://${ IS_INSTALLATION_TOKEN ? 'x-access-token:' : '' }${ GITHUB_TOKEN }@${ repo.fullName }.git`
+		this.gitUrl = `https://${ IS_INSTALLATION_TOKEN ? 'x-access-token:' : '' }${ IS_FINE_GRAINED ? 'oauth:' : '' }${ GITHUB_TOKEN }@${ repo.fullName }.git`
 
 		await this.clone()
 		await this.setIdentity()

--- a/src/config.js
+++ b/src/config.js
@@ -40,6 +40,10 @@ try {
 			key: 'CONFIG_PATH',
 			default: '.github/sync.yml'
 		}),
+		IS_FINE_GRAINED: getInput({
+			key: 'IS_FINE_GRAINED',
+			default: false
+		}),
 		COMMIT_BODY: getInput({
 			key: 'COMMIT_BODY',
 			default: ''

--- a/src/git.js
+++ b/src/git.js
@@ -9,6 +9,7 @@ const fs = require('fs')
 const {
 	GITHUB_TOKEN,
 	IS_INSTALLATION_TOKEN,
+	IS_FINE_GRAINED,
 	GIT_USERNAME,
 	GIT_EMAIL,
 	TMP_DIR,
@@ -56,7 +57,7 @@ class Git {
 		// Set values to current repo
 		this.repo = repo
 		this.workingDir = path.join(TMP_DIR, repo.uniqueName)
-		this.gitUrl = `https://${ IS_INSTALLATION_TOKEN ? 'x-access-token:' : '' }${ GITHUB_TOKEN }@${ repo.fullName }.git`
+		this.gitUrl = `https://${ IS_INSTALLATION_TOKEN ? 'x-access-token:' : '' }${ IS_FINE_GRAINED ? 'oauth:' : '' }${ GITHUB_TOKEN }@${ repo.fullName }.git`
 
 		await this.clone()
 		await this.setIdentity()


### PR DESCRIPTION
Hey 👋 

Have been trying out the beta [fine grained tokens](https://docs.github.com/en/organizations/managing-programmatic-access-to-your-organization/setting-a-personal-access-token-policy-for-your-organization). 

This adds support for fine grained tokens by:
- adding an optional IS_FINE_GRAINED boolean flag so it can change the clone url to be `https://oauth:my_token@github.com/my/repo`.

May be better way to do this so happy to see suggestions. Let me know I missed anything. Should be a non breaking change!