### PR TITLE
Added possibility to exclude subfolders 

### DIFF
--- a/.github/latest-tag.yml
+++ b/.github/latest-tag.yml
@@ -1,0 +1,15 @@
+- name: Run latest-tag
+  uses: EndBug/latest-tag@latest
+  with:
+    # You can change the name of the tag or branch with this input.
+    # Default: 'latest'
+    ref: 'latest'
+
+    # If a description is provided, the action will use it to create an annotated tag. If none is given, the action will create a lightweight tag.
+    # Default: ''
+    description: ''
+
+    # Force-update a branch instead of using a tag.
+    # Default: false
+    force-branch: false
+    

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+- name: Run latest-tag
+  uses: EndBug/latest-tag@latest
+  with:
+    # You can change the name of the tag or branch with this input.
+    # Default: 'latest'
+    ref: 'latest'
+
+    # If a description is provided, the action will use it to create an annotated tag. If none is given, the action will create a lightweight tag.
+    # Default: ''
+    description: ''
+
+    # Force-update a branch instead of using a tag.
+    # Default: false
+    force-branch: false

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -69,11 +69,32 @@ const copy = async (src, dest, deleteOrphaned, exclude) => {
 
 	const filterFunc = (file) => {
 
-		if (exclude !== undefined && exclude.includes(file)) {
-			core.debug(`Excluding file ${ file }`)
-			return false
-		}
 
+        if(exclude !== undefined){
+           
+            //Check if file-path is one of the present filepaths in the excluded paths
+            //This has presedence over the single file, and therefore returns before the single file check
+            let file_path = ''
+            if (file.endsWith('/')) {
+                //File item is a folder
+                file_path = file
+            } else {
+                //File item is a file
+                file_path = file.split('\/').slice(0,-1).join('/')+'/'
+            }
+            
+            if (exclude.includes(file_path)) {
+			    core.debug(`Excluding file ${ file } since its path is included as one of the excluded paths.`)
+                return false
+            }
+                
+                
+            //Or if the file itself is in the excluded files
+		    if (exclude.includes(file)) {
+			    core.debug(`Excluding file ${ file } since it is explicitly added in the exclusion list.`)
+			    return false
+		    }
+        }
 		return true
 	}
 


### PR DESCRIPTION
If a folder is added in the sync list, it is currently only possible to exclude specific files in that folder.
It would be useful to be able to exclude all the contents of subfolders of the folder to be synced.

This enhancement is an attempt to allow subfolders with all their contents to be excluded.