### PR TITLE
fix: Add maxBuffer to expensive git commands

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30465,7 +30465,7 @@ class Git {
 			Synced local file(s) with [${ GITHUB_REPOSITORY }](https://github.com/${ GITHUB_REPOSITORY }).
 
 			${ PR_BODY }
-			
+
 			${ changedFiles }
 
 			---
@@ -30623,7 +30623,8 @@ const execCmd = (command, workingDir, trimResult = true) => {
 		exec(
 			command,
 			{
-				cwd: workingDir
+				cwd: workingDir,
+				maxBuffer: 1024 * 1024 * 4
 			},
 			function(error, stdout) {
 				error ? reject(error) : resolve(

--- a/src/git.js
+++ b/src/git.js
@@ -421,7 +421,7 @@ class Git {
 			Synced local file(s) with [${ GITHUB_REPOSITORY }](https://github.com/${ GITHUB_REPOSITORY }).
 
 			${ PR_BODY }
-			
+
 			${ changedFiles }
 
 			---

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -48,7 +48,8 @@ const execCmd = (command, workingDir, trimResult = true) => {
 		exec(
 			command,
 			{
-				cwd: workingDir
+				cwd: workingDir,
+				maxBuffer: 1024 * 1024 * 4
 			},
 			function(error, stdout) {
 				error ? reject(error) : resolve(


### PR DESCRIPTION
Fixes #253

Default is 1024x1024x1, this seems to be a common increase especially if a project contains unicode characters.

- https://www.hacksparrow.com/nodejs/difference-between-spawn-and-exec-of-node-js-child-rocess.html
- https://nodejs.org/docs/latest-v16.x/api/child_process.html#maxbuffer-and-unicode
- https://stackoverflow.com/questions/61540352/rangeerror-err-child-process-stdio-maxbufferstdout-maxbuffer-length-exceeded

@BetaHuhn 