### PR TITLE
Updated README.md to use `v1.21.0` version instead of `v1` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@master
       - name: Run GitHub File Sync
-        uses: BetaHuhn/repo-file-sync-action@v1
+        uses: BetaHuhn/repo-file-sync-action@v1.21.0
         with:
           GH_PAT: ${{ secrets.GH_PAT }}
 ```
@@ -89,10 +89,10 @@ To always use the latest version of the action add the `latest` tag to the actio
 uses: BetaHuhn/repo-file-sync-action@latest
 ```
 
-If you want to make sure that your workflow doesn't suddenly break when a new major version is released, use the `v1` tag instead (recommended usage):
+If you want to make sure that your workflow doesn't suddenly break when a new major version is released, use the `v1.21.0` tag instead (recommended usage):
 
 ```yml
-uses: BetaHuhn/repo-file-sync-action@v1
+uses: BetaHuhn/repo-file-sync-action@v1.21.0
 ```
 
 With the `v1` tag you will always get the latest non-breaking version which will include potential bug fixes in the future. If you use a specific version, make sure to regularly check if a new version is available, or enable Dependabot.
@@ -358,7 +358,7 @@ By default [repo-file-sync-action](https://github.com/BetaHuhn/repo-file-sync-ac
 
 ```yml
 - name: Run GitHub File Sync
-  uses: BetaHuhn/repo-file-sync-action@v1
+  uses: BetaHuhn/repo-file-sync-action@v1.21.0
   with:
     GH_PAT: ${{ secrets.GH_PAT }}
     PR_LABELS: |
@@ -374,7 +374,7 @@ You can tell [repo-file-sync-action](https://github.com/BetaHuhn/repo-file-sync-
 
 ```yml
 - name: Run GitHub File Sync
-  uses: BetaHuhn/repo-file-sync-action@v1
+  uses: BetaHuhn/repo-file-sync-action@v1.21.0
   with:
     GH_PAT: ${{ secrets.GH_PAT }}
     ASSIGNEES: BetaHuhn
@@ -388,7 +388,7 @@ You can tell [repo-file-sync-action](https://github.com/BetaHuhn/repo-file-sync-
 
 ```yml
 - name: Run GitHub File Sync
-  uses: BetaHuhn/repo-file-sync-action@v1
+  uses: BetaHuhn/repo-file-sync-action@v1.21.0
   with:
     GH_PAT: ${{ secrets.GH_PAT }}
     REVIEWERS: |
@@ -428,7 +428,7 @@ If your repo name contains invalid characters, like a dot ([#32](https://github.
 **.github/workflows/sync.yml**
 
 ```yml
-uses: BetaHuhn/repo-file-sync-action@v1
+uses: BetaHuhn/repo-file-sync-action@v1.21.0
 with:
     GH_PAT: ${{ secrets.GH_PAT }}
     BRANCH_PREFIX: custom-branch
@@ -446,7 +446,7 @@ You can specify a custom commit body. This will be appended to the commit messag
 
 ```yml
 - name: Run GitHub File Sync
-  uses: BetaHuhn/repo-file-sync-action@v1
+  uses: BetaHuhn/repo-file-sync-action@v1.21.0
   with:
     GH_PAT: ${{ secrets.GH_PAT }}
     COMMIT_BODY: "Change-type: patch"
@@ -467,7 +467,7 @@ You can add more content to the PR body with the `PR_BODY` option. For example:
 
 ```yml
 - name: Run GitHub File Sync
-  uses: BetaHuhn/repo-file-sync-action@v1
+  uses: BetaHuhn/repo-file-sync-action@v1.21.0
   with:
     GH_PAT: ${{ secrets.GH_PAT }}
     PR_BODY: This is your custom PR Body
@@ -496,7 +496,7 @@ A fork of each target repository will be created on this account, and all change
 Note: while you can open pull requests to target repositories without write access, some features, like applying labels, are not possible.
 
 ```yml
-uses: BetaHuhn/repo-file-sync-action@v1
+uses: BetaHuhn/repo-file-sync-action@v1.21.0
 with:
     GH_PAT: ${{ secrets.GH_PAT }}
     FORK: file-sync-bot


### PR DESCRIPTION
The Readme has an older version of the action in code examples, which is fine, but the `v1` version is using Node.js 12, so if a user copy pastes some of the examples, they'll get those warnings and possibly some breakage in the future.

Especially this language in the current Readme might be confusing:
> If you want to make sure that your workflow doesn't suddenly break when a new major version is released, use the `v1` tag instead (recommended usage):

Or am I wrong and GitHub will always choose latest v1 version?