### PR TITLE
Bump to node20 in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ outputs:
     description: 'The URLs to the created Pull Requests as an array'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 branding:


### PR DESCRIPTION
As this shows in the logs now:

<tt>Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: BetaHuhn/repo-file-sync-action@v1.21.0. 
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
</tt>