### PR TITLE
Export list of modified files as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Here are all the inputs [repo-file-sync-action](https://github.com/BetaHuhn/repo
 ### Outputs
 
 The action sets the `pull_request_urls` output to the URLs of any created Pull Requests. It will be an array of URLs to each PR, e.g. `'["https://github.com/username/repository/pull/number", "..."]'`.
+A `modified_files` array consisting of absolute paths to all modified/rendered files is also exported, which could be used for further validation or post-processing. e.g. `["tmp/github.com/my-org/my-repo@default/.github/workflows/build.yaml"]`
 
 ## 🛠️ Sync Configuration
 

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ async function run() {
 
 	const prUrls = []
 
+	const modifiedFiles = []
 	await forEach(repos, async (item) => {
 		core.info(`Repository Info`)
 		core.info(`Slug		: ${ item.repo.name }`)
@@ -111,6 +112,8 @@ async function run() {
 						useOriginalMessage: useOriginalCommitMessage,
 						commitMessage: message[destExists].commit
 					})
+
+					modifiedFiles.push(dest)
 				}
 			})
 
@@ -200,7 +203,11 @@ async function run() {
 			core.setFailed(err.message)
 			core.debug(err)
 		}
+
 	})
+
+	core.setOutput('modified_files', modifiedFiles)
+	core.debug('Modified files: ' + modifiedFiles)
 
 	// If we created any PRs, set their URLs as the output
 	if (prUrls) {


### PR DESCRIPTION
Use cases: 
- run the action in `DRY_MODE` and use the list of modified files to validate YAMLs (especially those rendered using templates) in the next steps.
- simply print, or generate some fancy preview on modified files in PRs